### PR TITLE
Add: Haskell (GHC)

### DIFF
--- a/compilers/default.nix
+++ b/compilers/default.nix
@@ -6,6 +6,7 @@
   koka = import ./koka {inherit pkgs;};
   mercury = import ./mercury {inherit pkgs;};
   cobol = import ./cobol {inherit pkgs;};
+  haskell = import ./haskell {pkgs = allpkgs.release2411;};
   haxe = import ./haxe {inherit pkgs;};
   raku = import ./raku {pkgs = allpkgs.release2411;};
   java = import ./java {pkgs = allpkgs.release2411;};
@@ -20,6 +21,7 @@ in {
     koka
     mercury
     cobol
+    haskell
     haxe
     raku
     java

--- a/compilers/haskell/default.nix
+++ b/compilers/haskell/default.nix
@@ -1,0 +1,12 @@
+{pkgs, ...}: let
+  myHaskell = pkgs.haskell.compiler.ghc983;
+in
+  pkgs.writeShellScriptBin "ghc" "exec ${myHaskell}/bin/ghc $@"
+  // {
+    traojudge = {
+      name = "Haskell";
+      binName = "ghc";
+      compile = ghc: "${myHaskell} \"$SRC\"";
+      run = ghc: "exec \"$DIST\"";
+    };
+  }

--- a/compilers/haskell/main.hs
+++ b/compilers/haskell/main.hs
@@ -1,0 +1,1 @@
+main = putStrLn "Hello World"


### PR DESCRIPTION
closes traP-JP/traO-Judge-docs#57
- [haskell.compiler.ghc983](https://search.nixos.org/packages?channel=25.05&show=haskell.compiler.ghc983&from=0&size=50&sort=relevance&type=packages&query=ghc+haskell)